### PR TITLE
Add README for Notes Folder

### DIFF
--- a/notes/README.md
+++ b/notes/README.md
@@ -1,1 +1,21 @@
 # Notes
+
+## Purpose
+
+The `notes/` folder serves as a placeholder for future documentation and additional
+resources. However, meeting agendas, minutes of meetings (MoMs), and other
+collaborative notes are managed and shared using the repository's **Issues** section.
+
+## Meeting Management
+
+- **Meeting Agendas**: Agendas for upcoming meetings are prepared and shared through
+  GitHub Issues to ensure all team members are aligned before the meeting.
+  Agenda Issues are titled according to the meeting sequence.
+- **Minutes of Meetings (MoMs)**: After each meeting, the key points, decisions,
+  and action items are documented in the same Issues section for easy tracking.
+
+## How to Access Meeting Notes
+
+1. Navigate to the **Issues** tab in the repository.
+2. Look for label `Meeting` to quickly find relevant notes.
+3. Use the search functionality to locate specific topics or past meeting discussions.


### PR DESCRIPTION
This PR adds a README file to the notes/ folder. The README explains the purpose of the folder and outlines how we manage meeting agendas and minutes of meetings (MoMs) using GitHub Issues. It includes:

- A brief overview of the notes/ folder.
- Instructions on accessing and managing notes through Issues.